### PR TITLE
fix(vite): add missing CartApp.vue and mount Vue

### DIFF
--- a/app/Domain/Cart/Cart.php
+++ b/app/Domain/Cart/Cart.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Cart;
+
+final class Cart implements CartInterface
+{
+  /** @var array<int,CartItem> keyed by product id */
+  private array $items = [];
+
+  public function addItem(Product $product, int $qty): void
+  {
+    if ($qty <= 0) throw new \InvalidArgumentException('Quantity must be > 0');
+
+    $existing = $this->items[$product->id] ?? null;
+    if ($existing) {
+      $existing->qty += $qty;
+      return;
+    }
+    $this->items[$product->id] = new CartItem($product, $qty);
+  }
+
+  public function updateQuantity(int $productId, int $qty): void
+  {
+    if (!isset($this->items[$productId])) return;
+    if ($qty <= 0) {
+      $this->removeItem($productId);
+    } else {
+      $this->items[$productId]->qty = $qty;
+    }
+  }
+
+  public function removeItem(int $productId): void
+  {
+    unset($this->items[$productId]);
+  }
+
+  /** @return CartItem[] */
+  public function items(): array
+  {
+    return array_values($this->items);
+  }
+
+  public function checkoutUrl(): string
+  {
+    return 'https://example.com/checkout';
+  }
+
+  public function subTotal(): float
+  {
+    $sum = 0.0;
+    foreach ($this->items as $item) $sum += $item->lineTotal();
+    return round($sum, 2);
+  }
+
+  public function total(float $taxRate = 0.0, float $discount = 0.0): float
+  {
+    return $this->totalsBreakdown($taxRate, $discount)['total'];
+  }
+
+  private function totalsBreakdown(float $taxRate, float $discount): array
+  {
+    if ($taxRate < 0.0)  throw new \InvalidArgumentException('Tax rate must be >= 0');
+    if ($discount < 0.0) throw new \InvalidArgumentException('Discount must be >= 0');
+
+    $subtotal      = $this->subTotal();
+    $afterDiscount = round(max(0.0, $subtotal - $discount), 2);
+    $tax           = round($afterDiscount * $taxRate, 2);
+    $total         = round($afterDiscount + $tax, 2);
+
+    return compact('subtotal', 'afterDiscount', 'taxRate', 'discount', 'tax', 'total');
+  }
+
+  public function toArrayForApi(float $taxRate = 0.0, float $discount = 0.0): array
+  {
+    $t = $this->totalsBreakdown($taxRate, $discount);
+    return [
+      'items'      => array_map(fn($i) => $i->jsonSerialize(), $this->items()),
+      'subtotal'   => $t['subtotal'],
+      'discount'   => $t['discount'],
+      'tax_rate'   => $t['taxRate'],
+      'tax'        => $t['tax'],
+      'total'      => $t['total'],
+      'checkout'   => $this->checkoutUrl(),
+    ];
+  }
+
+  /** Persist minimal data in session */
+  public function toStorageArray(): array
+  {
+    return [
+      'items' => array_map(function (CartItem $i) {
+        return [
+          'product' => [
+            'id'    => $i->product->id,
+            'name'  => $i->product->name,
+            'price' => $i->product->price,
+          ],
+          'qty' => $i->qty,
+        ];
+      }, $this->items()),
+    ];
+  }
+
+  public static function fromStorageArray(array $data): self
+  {
+    $cart = new self();
+    foreach (($data['items'] ?? []) as $row) {
+      $p = $row['product'];
+      $cart->addItem(new Product((int)$p['id'], (string)$p['name'], (float)$p['price']), (int) $row['qty']);
+    }
+    return $cart;
+  }
+}

--- a/app/Domain/Cart/CartInterface.php
+++ b/app/Domain/Cart/CartInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Cart;
+
+interface CartInterface
+{
+  public function addItem(Product $product, int $qty): void;
+  public function updateQuantity(int $productId, int $qty): void;
+  public function removeItem(int $productId): void;
+  /** @return CartItem[] */
+  public function items(): array;
+  public function subTotal(): float;
+  public function total(float $taxRate = 0.0, float $discount = 0.0): float;
+  public function checkoutUrl(): string;
+  public function toArrayForApi(float $taxRate = 0.0, float $discount = 0.0): array;
+
+  /** Storage helpers */
+  public function toStorageArray(): array;
+  public static function fromStorageArray(array $data): self;
+}

--- a/app/Domain/Cart/CartItem.php
+++ b/app/Domain/Cart/CartItem.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Cart;
+
+final class CartItem implements \JsonSerializable
+{
+  public function __construct(
+    public Product $product,
+    public int $qty
+  ) {
+    if ($this->qty <= 0) throw new \InvalidArgumentException('Quantity must be > 0');
+  }
+
+  public function lineTotal(): float
+  {
+    return round($this->product->price * $this->qty, 2);
+  }
+
+  public function jsonSerialize(): array
+  {
+    return [
+      'product'   => [
+        'id'    => $this->product->id,
+        'name'  => $this->product->name,
+        'price' => $this->product->price,
+      ],
+      'quantity'  => $this->qty,
+      'lineTotal' => $this->lineTotal(),
+    ];
+  }
+}

--- a/app/Domain/Cart/Product.php
+++ b/app/Domain/Cart/Product.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Cart;
+
+final class Product
+{
+  public function __construct(
+    public readonly int $id,
+    public readonly string $name,
+    public readonly float $price
+  ) {
+    if ($this->price <= 0) throw new \InvalidArgumentException('Price must be > 0');
+  }
+}

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCartItemRequest;
+use App\Http\Requests\UpdateCartItemRequest;
+use App\Services\CartService;
+use Illuminate\Http\Request;
+
+final class CartController extends Controller
+{
+  public function __construct(private CartService $cart) {}
+
+  public function show(Request $request)
+  {
+    $taxRate  = (float) $request->query('tax_rate', 0.0);
+    $discount = (float) $request->query('discount', 0.0);
+    return response()->json($this->cart->get($taxRate, $discount));
+  }
+
+  public function store(StoreCartItemRequest $request)
+  {
+    $d = $request->validated();
+    $payload = $this->cart->add((int)$d['product_id'], (string)$d['name'], (float)$d['price'], (int)$d['quantity']);
+    return response()->json($payload, 201);
+  }
+
+  public function update(UpdateCartItemRequest $request, int $productId)
+  {
+    $qty = (int) $request->validated()['quantity'];
+    $payload = $this->cart->update($productId, $qty);
+    return response()->json($payload);
+  }
+
+  public function destroy(int $productId)
+  {
+    $payload = $this->cart->remove($productId);
+    return response()->json($payload, 200);
+  }
+
+  public function clear()
+  {
+    return response()->json($this->cart->clear());
+  }
+}

--- a/app/Http/Requests/StoreCartItemRequest.php
+++ b/app/Http/Requests/StoreCartItemRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class StoreCartItemRequest extends FormRequest
+{
+  public function authorize(): bool
+  {
+    return true;
+  }
+  public function rules(): array
+  {
+    return [
+      'product_id' => ['required', 'integer', 'min:1'],
+      'name'       => ['required', 'string', 'max:255'],
+      'price'      => ['required', 'numeric', 'min:0.01'],
+      'quantity'   => ['required', 'integer', 'min:1'],
+    ];
+  }
+}

--- a/app/Http/Requests/UpdateCartItemRequest.php
+++ b/app/Http/Requests/UpdateCartItemRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateCartItemRequest extends FormRequest
+{
+  public function authorize(): bool
+  {
+    return true;
+  }
+  public function rules(): array
+  {
+    return [
+      'quantity' => ['required', 'integer', 'min:0'], // 0 => remove
+    ];
+  }
+}

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Domain\Cart\{Cart, CartInterface, Product};
+use Illuminate\Contracts\Session\Session;
+
+final class CartService
+{
+  private const KEY = 'cart';
+
+  public function __construct(private Session $session) {}
+
+  private function load(): CartInterface
+  {
+    $data = $this->session->get(self::KEY);
+    return is_array($data) ? Cart::fromStorageArray($data) : new Cart();
+  }
+
+  private function save(CartInterface $cart): void
+  {
+    $this->session->put(self::KEY, $cart->toStorageArray());
+  }
+
+  public function get(float $taxRate = 0.0, float $discount = 0.0): array
+  {
+    return $this->load()->toArrayForApi($taxRate, $discount);
+  }
+
+  public function add(int $productId, string $name, float $price, int $quantity): array
+  {
+    $cart = $this->load();
+    $cart->addItem(new Product($productId, $name, $price), $quantity);
+    $this->save($cart);
+    return $cart->toArrayForApi();
+  }
+
+  public function update(int $productId, int $quantity): array
+  {
+    $cart = $this->load();
+    $cart->updateQuantity($productId, $quantity);
+    $this->save($cart);
+    return $cart->toArrayForApi();
+  }
+
+  public function remove(int $productId): array
+  {
+    $cart = $this->load();
+    $cart->removeItem($productId);
+    $this->save($cart);
+    return $cart->toArrayForApi();
+  }
+
+  public function clear(): array
+  {
+    $this->session->forget(self::KEY);
+    return (new Cart())->toArrayForApi();
+  }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,8 +6,9 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        api: __DIR__ . '/../routes/api.php',
+        web: __DIR__ . '/../routes/web.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
+                "@vitejs/plugin-vue": "^6.0.1",
                 "axios": "^1.11.0",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0.0",
@@ -565,6 +566,13 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.29",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
+            "integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.49.0",
@@ -1129,6 +1137,23 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
+            "integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-beta.29"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "vue": "^3.2.25"
+            }
         },
         "node_modules/@vue/compiler-core": {
             "version": "3.5.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "vue": "^3.5.20"
+            },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
                 "axios": "^1.11.0",
@@ -11,6 +14,52 @@
                 "laravel-vite-plugin": "^2.0.0",
                 "tailwindcss": "^4.0.0",
                 "vite": "^7.0.4"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -504,7 +553,6 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1082,6 +1130,106 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.20.tgz",
+            "integrity": "sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.3",
+                "@vue/shared": "3.5.20",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.20.tgz",
+            "integrity": "sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.20",
+                "@vue/shared": "3.5.20"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
+            "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.3",
+                "@vue/compiler-core": "3.5.20",
+                "@vue/compiler-dom": "3.5.20",
+                "@vue/compiler-ssr": "3.5.20",
+                "@vue/shared": "3.5.20",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.17",
+                "postcss": "^8.5.6",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.20.tgz",
+            "integrity": "sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.20",
+                "@vue/shared": "3.5.20"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.20.tgz",
+            "integrity": "sha512-hS8l8x4cl1fmZpSQX/NXlqWKARqEsNmfkwOIYqtR2F616NGfsLUm0G6FQBK6uDKUCVyi1YOL8Xmt/RkZcd/jYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.20"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.20.tgz",
+            "integrity": "sha512-vyQRiH5uSZlOa+4I/t4Qw/SsD/gbth0SW2J7oMeVlMFMAmsG1rwDD6ok0VMmjXY3eI0iHNSSOBilEDW98PLRKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.20",
+                "@vue/shared": "3.5.20"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.20.tgz",
+            "integrity": "sha512-KBHzPld/Djw3im0CQ7tGCpgRedryIn4CcAl047EhFTCCPT2xFf4e8j6WeKLgEEoqPSl9TYqShc3Q6tpWpz/Xgw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.20",
+                "@vue/runtime-core": "3.5.20",
+                "@vue/shared": "3.5.20",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.20.tgz",
+            "integrity": "sha512-HthAS0lZJDH21HFJBVNTtx+ULcIbJQRpjSVomVjfyPkFSpCwvsPTA+jIzOaUm3Hrqx36ozBHePztQFg6pj5aKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.20",
+                "@vue/shared": "3.5.20"
+            },
+            "peerDependencies": {
+                "vue": "3.5.20"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.20.tgz",
+            "integrity": "sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==",
+            "license": "MIT"
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1254,6 +1402,12 @@
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
         },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1308,6 +1462,18 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/es-define-property": {
@@ -1410,6 +1576,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -1896,7 +2068,6 @@
             "version": "0.30.18",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
             "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -1978,7 +2149,6 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -1997,7 +2167,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -2017,7 +2186,6 @@
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
             "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -2126,7 +2294,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -2346,6 +2513,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vue": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.20.tgz",
+            "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.20",
+                "@vue/compiler-sfc": "3.5.20",
+                "@vue/runtime-dom": "3.5.20",
+                "@vue/server-renderer": "3.5.20",
+                "@vue/shared": "3.5.20"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@vitejs/plugin-vue": "^6.0.1",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
         "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",
         "vite": "^7.0.4"
+    },
+    "dependencies": {
+        "vue": "^3.5.20"
     }
 }

--- a/resources/js/CartApp.vue
+++ b/resources/js/CartApp.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+
+const taxRate = ref(0.0725);
+const discount = ref(0.00);
+const cart = ref({ items: [], subtotal: 0, tax: 0, total: 0 });
+
+const form = ref({ product_id: 1, name: 'Notebook', price: 3.5, quantity: 1 });
+
+async function fetchCart() {
+  const q = new URLSearchParams({ tax_rate: String(taxRate.value), discount: String(discount.value) });
+  const res = await fetch(`/api/cart?${q.toString()}`);
+  cart.value = await res.json();
+}
+
+async function addItem() {
+  await fetch('/api/cart/items', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form.value),
+  });
+  await fetchCart();
+}
+
+async function updateQty(productId, qty) {
+  await fetch(`/api/cart/items/${productId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ quantity: qty }),
+  });
+  await fetchCart();
+}
+
+async function removeItem(productId) {
+  await fetch(`/api/cart/items/${productId}`, { method: 'DELETE' });
+  await fetchCart();
+}
+
+async function clearCart() {
+  await fetch('/api/cart', { method: 'DELETE' });
+  await fetchCart();
+}
+
+onMounted(fetchCart);
+
+const hasItems = computed(() => (cart.value.items ?? []).length > 0);
+</script>
+
+<template>
+  <main style="max-width: 800px; margin: 2rem auto; font-family: ui-sans-serif, system-ui;">
+    <h1>Shopping Cart</h1>
+
+    <section style="display: grid; gap: .5rem; grid-template-columns: repeat(4, 1fr); align-items: end;">
+      <label>Product ID <input type="number" v-model.number="form.product_id" min="1" /></label>
+      <label>Name <input type="text" v-model="form.name" /></label>
+      <label>Price <input type="number" step="0.01" min="0.01" v-model.number="form.price" /></label>
+      <label>Qty <input type="number" min="1" v-model.number="form.quantity" /></label>
+      <button @click="addItem">Add to cart</button>
+    </section>
+
+    <section style="margin-top:1rem; display:flex; gap:1rem; align-items:center;">
+      <label>Tax Rate <input type="number" step="0.0001" v-model.number="taxRate" @change="fetchCart" /></label>
+      <label>Discount <input type="number" step="0.01" min="0" v-model.number="discount" @change="fetchCart" /></label>
+      <button @click="clearCart">Clear</button>
+      <button @click="fetchCart">Refresh</button>
+    </section>
+
+    <section v-if="hasItems" style="margin-top:1rem;">
+      <table border="1" cellpadding="6" cellspacing="0" width="100%">
+        <thead>
+          <tr>
+            <th style="text-align:left;">Product</th>
+            <th>Price</th>
+            <th>Qty</th>
+            <th>Line Total</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in cart.items" :key="row.product.id">
+            <td>{{ row.product.name }} (#{{ row.product.id }})</td>
+            <td style="text-align:right;">{{ row.product.price.toFixed(2) }}</td>
+            <td style="text-align:center;">
+              <input type="number" min="0" :value="row.quantity"
+                @change="e => updateQty(row.product.id, Number(e.target.value))" />
+            </td>
+            <td style="text-align:right;">{{ row.lineTotal.toFixed(2) }}</td>
+            <td><button @click="removeItem(row.product.id)">Remove</button></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div style="margin-top:1rem; text-align:right;">
+        <div>Subtotal: <strong>{{ cart.subtotal.toFixed(2) }}</strong></div>
+        <div>Tax: <strong>{{ cart.tax.toFixed(2) }}</strong></div>
+        <div>Total: <strong>{{ cart.total.toFixed(2) }}</strong></div>
+      </div>
+    </section>
+
+    <p v-else style="margin-top:1rem;">Cart is empty.</p>
+  </main>
+</template>
+
+<style scoped>
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: .9rem;
+}
+
+input {
+  padding: .4rem;
+}
+
+button {
+  padding: .5rem .8rem;
+}
+</style>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,6 @@
-import './bootstrap';
+import './bootstrap'
 import { createApp } from 'vue'
 import CartApp from './components/CartApp.vue'
 
+console.log('Mounting Vue…')
 createApp(CartApp).mount('#app')

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,5 @@
 import './bootstrap';
+import { createApp } from 'vue'
+import CartApp from './components/CartApp.vue'
+
+createApp(CartApp).mount('#app')

--- a/resources/js/components/CartApp.vue
+++ b/resources/js/components/CartApp.vue
@@ -1,0 +1,9 @@
+<template>
+  <main style="padding:2rem;font-family:ui-sans-serif,system-ui">
+    <h1>Cart UI mounted ✅</h1>
+    <p>If you see this, Vue + Vite are working.</p>
+  </main>
+</template>
+<script setup>
+// replace with your real CartApp later
+</script>

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -1,15 +1,12 @@
 <!doctype html>
 <html lang="en">
-
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
   <title>Shopping Cart</title>
   @vite('resources/js/app.js')
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
-
 <body>
-  <div id="app"></div>
+  <div id="app">Loading…</div>
 </body>
-
 </html>

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Shopping Cart</title>
+  @vite('resources/js/app.js')
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+  <div id="app"></div>
+</body>
+
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CartController;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Session\Middleware\StartSession;
+
+Route::middleware(['api', EncryptCookies::class, AddQueuedCookiesToResponse::class, StartSession::class])->group(function () {
+  Route::get('/cart', [CartController::class, 'show']);
+  Route::post('/cart/items', [CartController::class, 'store']);
+  Route::patch('/cart/items/{productId}', [CartController::class, 'update']);
+  Route::delete('/cart/items/{productId}', [CartController::class, 'destroy']);
+  Route::delete('/cart', [CartController::class, 'clear']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,4 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::view('/', 'cart');

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,11 @@
-import { defineConfig } from 'vite';
-import laravel from 'laravel-vite-plugin';
-import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite'
+import laravel from 'laravel-vite-plugin'
+import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-    plugins: [
-        laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
-            refresh: true,
-        }),
-        tailwindcss(),
-    ],
-});
+  server: { host: '0.0.0.0', port: 5173 },
+  plugins: [
+    laravel({ input: ['resources/js/app.js'], refresh: true }),
+    vue(),
+  ],
+})


### PR DESCRIPTION

# Change Log

- Add resources/js/components/CartApp.vue (placeholder UI)
- Ensure resources/js/app.js imports ./components/CartApp.vue and mounts it
- Keep vite.config.js with @vitejs/plugin-vue so SFCs compile

- Domain split under App/Domain/Cart:
  - Cart.php, CartItem.php, Product.php, CartInterface.php
- Session persistence service: app/Services/CartService.php
- HTTP layer:
  - Controller: app/Http/Controllers/CartController.php
  - Requests: StoreCartItemRequest.php, UpdateCartItemRequest.php
- API routes with session middleware: routes/api.php
- Enable Vue app:
  - resources/js/app.js (mounts CartApp.vue)
  - resources/js/components/CartApp.vue
  - Blade view: resources/views/cart.blade.php
- Web route: routes/web.php -> Route::view('/', 'cart')
- package.json / lock updated by Vite/Vue install
