### PR TITLE
feat(products): add images + Faker Commerce names; wire through API & UI

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -8,12 +8,13 @@ final class ProductController extends Controller
 {
   public function index()
   {
-    // Cast price to float for the front end
-    $list = Product::query()->orderBy('id')->get()->map(fn($p) => [
-      'id'    => (int) $p->id,
-      'name'  => $p->name,
-      'price' => (float) $p->price,
-    ])->values();
+    $list = \App\Models\Product::query()->orderBy('id')->get()
+      ->map(fn($p) => [
+        'id'        => (int) $p->id,
+        'name'      => $p->name,
+        'price'     => (float) $p->price,
+        'image_url' => $p->image_url ?: "https://picsum.photos/seed/{$p->id}/600/400",
+      ])->values();
 
     return response()->json(['products' => $list]);
   }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Product extends Model
 {
-  protected $fillable = ['name', 'price'];
-  protected $casts = ['price' => 'decimal:2']; // stored as DECIMAL(…,2)
+  use HasFactory;
+
+  protected $fillable = ['name', 'price', 'image_url'];
+  protected $casts = ['price' => 'decimal:2'];
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
         "laravel/sail": "^1.41",
+        "mbezhanov/faker-provider-collection": "^2.0",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce69b617bd1544107566e524a2023d29",
+    "content-hash": "c42d4b14e58eaa25302cfa012eeac8f7",
     "packages": [
         {
             "name": "brick/math",
@@ -6674,6 +6674,57 @@
                 "source": "https://github.com/laravel/sail"
             },
             "time": "2025-08-25T19:28:31+00:00"
+        },
+        {
+            "name": "mbezhanov/faker-provider-collection",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mbezhanov/faker-provider-collection.git",
+                "reference": "f6e903c38aa18680fc6e80b6965fc6df40b1aa1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mbezhanov/faker-provider-collection/zipball/f6e903c38aa18680fc6e80b6965fc6df40b1aa1e",
+                "reference": "f6e903c38aa18680fc6e80b6965fc6df40b1aa1e",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.13",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.3",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Bezhanov\\Faker\\": "src/Faker"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marin Bezhanov",
+                    "email": "marin.bezhanov@gmail.com",
+                    "homepage": "http://marinbezhanov.com"
+                }
+            ],
+            "description": "A collection of custom providers for the Faker library",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/mbezhanov/faker-provider-collection/issues",
+                "source": "https://github.com/mbezhanov/faker-provider-collection/tree/2.0.2"
+            },
+            "time": "2023-12-26T14:31:52+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Bezhanov\Faker\Provider\Commerce as CommerceProvider;
+
+class ProductFactory extends Factory
+{
+  protected $model = Product::class;
+
+  public function definition(): array
+  {
+    // enable Commerce provider for productName()
+    if (!method_exists($this->faker, 'productName')) {
+      $this->faker->addProvider(new CommerceProvider($this->faker));
+    }
+
+    $name  = $this->faker->productName();              // ≈ faker.commerce.product()
+    $price = $this->faker->randomFloat(2, 0.5, 99.99);
+    $seed  = $this->faker->unique()->numberBetween(1, 1_000_000);
+
+    return [
+      'name'      => $name,
+      'price'     => $price,
+      'image_url' => "https://picsum.photos/seed/{$seed}/600/400",
+    ];
+  }
+}

--- a/database/migrations/2025_08_29_075647_add_image_url_to_products_table.php
+++ b/database/migrations/2025_08_29_075647_add_image_url_to_products_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('image_url')->nullable()->after('price');
+        });
+    }
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('image_url');
+        });
+    }
+};

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -9,15 +9,7 @@ class ProductSeeder extends Seeder
 {
   public function run(): void
   {
-    $items = [
-      ['name' => 'Notebook', 'price' => 3.50],
-      ['name' => 'Pencil',   'price' => 1.25],
-      ['name' => 'Eraser',   'price' => 0.99],
-      ['name' => 'Ruler',    'price' => 2.50],
-      ['name' => 'Backpack', 'price' => 24.00],
-    ];
-    foreach ($items as $i) {
-      Product::updateOrCreate(['name' => $i['name']], $i);
-    }
+    Product::truncate();             // reset for demo/dev
+    Product::factory()->count(12)->create();
   }
 }

--- a/resources/js/components/ShopApp.vue
+++ b/resources/js/components/ShopApp.vue
@@ -43,12 +43,14 @@ onMounted(load)
 
     <section
       style="display:grid; gap:1rem; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); margin-top:1rem;">
-      <article v-for="p in products" :key="p.id" style="border:1px solid #ddd; border-radius:12px; padding:1rem;">
+      <article v-for="p in products" :key="p.id" style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+        <img :src="p.image_url" :alt="p.name"
+          style="width:100%;height:140px;object-fit:cover;border-radius:8px;margin-bottom:.5rem;" loading="lazy" />
         <h3 style="margin:.2rem 0">{{ p.name }}</h3>
-        <p style="color:#555; margin:.2rem 0">$ {{ Number(p.price).toFixed(2) }}</p>
-        <div style="display:flex; gap:.5rem; align-items:center;">
-          <input type="number" min="1" v-model.number="qty[p.id]" style="width:80px; padding:.4rem;" />
-          <button :disabled="busy" @click="addToCart(p)" style="padding:.5rem .8rem; cursor:pointer;">Add to
+        <p style="color:#555;margin:.2rem 0">$ {{ Number(p.price).toFixed(2) }}</p>
+        <div style="display:flex;gap:.5rem;align-items:center;">
+          <input type="number" min="1" v-model.number="qty[p.id]" style="width:80px;padding:.4rem;" />
+          <button :disabled="busy" @click="addToCart(p)" style="padding:.5rem .8rem;cursor:pointer;">Add to
             Cart</button>
         </div>
       </article>


### PR DESCRIPTION
# feat(products): add images + Faker Commerce names; wire through API & UI
## Change Log
- add image_url column (migration)
- Product model: HasFactory, fillable image_url, cast price
- ProductFactory: use bezhanov/faker-provider-collection (Commerce::productName) and picsum images
- ProductSeeder: seed via factory (e.g., 12 items)
- ProductController@index: include image_url in /api/products response
- ShopApp.vue: render product images

chore(dev): add faker provider to composer (dev)